### PR TITLE
[bugfix]修复缓存列表模块只读不生效问题

### DIFF
--- a/flux-frontend/src/views/monitor/cache/list.vue
+++ b/flux-frontend/src/views/monitor/cache/list.vue
@@ -154,7 +154,7 @@
                                 >
                                     <el-input
                                         v-model="cacheForm.cacheName"
-                                        :readOnly="true"
+                                        :readonly="true"
                                     />
                                 </el-form-item>
                             </el-col>
@@ -162,7 +162,7 @@
                                 <el-form-item label="缓存键名:" prop="cacheKey">
                                     <el-input
                                         v-model="cacheForm.cacheKey"
-                                        :readOnly="true"
+                                        :readonly="true"
                                     />
                                 </el-form-item>
                             </el-col>
@@ -175,7 +175,7 @@
                                         v-model="cacheForm.cacheValue"
                                         type="textarea"
                                         :rows="8"
-                                        :readOnly="true"
+                                        :readonly="true"
                                     />
                                 </el-form-item>
                             </el-col>


### PR DESCRIPTION
修改`<el-input>`属性：readOnly -> readonly，使只读生效